### PR TITLE
Fix for mapfiles and symfiles. 

### DIFF
--- a/src/link/mapfile.c
+++ b/src/link/mapfile.c
@@ -72,14 +72,13 @@ MapfileInitBank(SLONG bank)
 void 
 MapfileWriteSection(struct sSection * pSect)
 {
-	if (!mf && !sf)
-		return;
-
 	SLONG i;
 
-	fprintf(mf, "  SECTION: $%04lX-$%04lX ($%04lX bytes)\n",
-	    pSect->nOrg, pSect->nOrg + pSect->nByteSize - 1,
-	    pSect->nByteSize);
+	if (mf) {
+		fprintf(mf, "  SECTION: $%04lX-$%04lX ($%04lX bytes)\n",
+		    pSect->nOrg, pSect->nOrg + pSect->nByteSize - 1,
+		    pSect->nByteSize);
+	}
 
 	for (i = 0; i < pSect->nNumberOfSymbols; i += 1) {
 		struct sSymbol *pSym;


### PR DESCRIPTION
Before, you couldn't define a mapfile unless you also defined a symfile. If you did, it would segfault.