### PR TITLE
Fixed WRAMX, VRAM and SRAM banks.

### DIFF
--- a/src/asm/asmy.y
+++ b/src/asm/asmy.y
@@ -1073,7 +1073,7 @@ section:
 				}
 			} else if ($4 == SECT_WRAMX) {
 				if ($8 >= 1 && $8 <= 7) {
-					out_NewAbsSection($2, $4, -1, $8);
+					out_NewAbsSection($2, $4, -1, $8-1);
 				} else {
 					yyerror("WRAMX bank value $%x out of range (1 to 7)", $8);
 				}
@@ -1110,7 +1110,7 @@ section:
 			} else if ($4 == SECT_WRAMX) {
 				if ($6 >= 0 && $6 < 0x10000) {
 					if ($11 >= 1 && $11 <= 7) {
-						out_NewAbsSection($2, $4, $6, $11);
+						out_NewAbsSection($2, $4, $6, $11-1);
 					} else {
 						yyerror("WRAMX bank value $%x out of range (1 to 7)", $11);
 					}

--- a/src/extern/err.c
+++ b/src/extern/err.c
@@ -26,9 +26,9 @@
 #include <stdlib.h>
 #include "extern/err.h"
 
-#ifndef __MINGW32__
+//#ifndef __MINGW32__
 char *__progname;
-#endif
+//#endif
 
 void rgbds_vwarn(const char *fmt, va_list ap)
 {

--- a/src/link/assign.c
+++ b/src/link/assign.c
@@ -305,6 +305,7 @@ AssignVRAMSections(void)
 		if ((org = area_AllocVRAMAnyBank(pSection->nByteSize)) != -1) {
 			pSection->nOrg = org & 0xFFFF;
 			pSection->nBank = org >> 16;
+			//pSection->nBank += BANK_VRAM; // Not needed here
 			pSection->oAssigned = 1;
 			DOMAXVBANK(pSection->nBank);
 		} else {
@@ -324,6 +325,7 @@ AssignSRAMSections(void)
 		if ((org = area_AllocSRAMAnyBank(pSection->nByteSize)) != -1) {
 			pSection->nOrg = org & 0xFFFF;
 			pSection->nBank = org >> 16;
+			pSection->nBank += BANK_SRAM;
 			pSection->oAssigned = 1;
 			DOMAXSBANK(pSection->nBank);
 		} else {
@@ -343,6 +345,7 @@ AssignWRAMSections(void)
 		if ((org = area_AllocWRAMAnyBank(pSection->nByteSize)) != -1) {
 			pSection->nOrg = org & 0xFFFF;
 			pSection->nBank = org >> 16;
+			pSection->nBank += BANK_WRAMX - 1;
 			pSection->oAssigned = 1;
 			DOMAXWBANK(pSection->nBank);
 		} else {
@@ -557,8 +560,8 @@ AssignSections(void)
 						 * bank are hardcoded.
 						 */
 
-						if (pSection->nBank >= 1
-						    && pSection->nBank <= 7) {
+						if (pSection->nBank >= (1-1)
+						    && pSection->nBank <= (7-1)) {
 							pSection->nBank +=
 							    BANK_WRAMX;
 							if (area_AllocAbs
@@ -704,7 +707,9 @@ AssignSections(void)
 	 * Next, let's assign all the bankfixed ONLY ROMX sections...
 	 *
 	 */
-
+	
+	// Assign floating sections of non-swappable bank
+	
 	pSection = pSections;
 	while (pSection) {
 		if (pSection->oAssigned == 0
@@ -890,7 +895,9 @@ AssignSections(void)
 		}
 		pSection = pSection->pNext;
 	}
-
+	
+	// Assign floating sections (org and bank) of swappable banks
+	
 	AssignCodeSections();
 	AssignVRAMSections();
 	AssignWRAMSections();

--- a/src/link/mapfile.c
+++ b/src/link/mapfile.c
@@ -53,19 +53,36 @@ MapfileInitBank(SLONG bank)
 {
 	if (mf) {
 		currentbank = bank;
-		if (bank == 0)
-			fprintf(mf, "Bank #0 (HOME):\n");
+		if (bank == BANK_ROM0)
+			fprintf(mf, "ROM Bank #0 (HOME):\n");
 		else if (bank < BANK_WRAM0)
-			fprintf(mf, "Bank #%ld:\n", bank);
+			fprintf(mf, "ROM Bank #%ld:\n", bank);
 		else if (bank == BANK_WRAM0)
-			fprintf(mf, "WRAM0:\n");
+			fprintf(mf, "WRAM Bank #0:\n");
+		else if (bank < BANK_VRAM)
+			fprintf(mf, "WRAM Bank #%ld:\n", bank - BANK_WRAMX + 1);
 		else if (bank == BANK_HRAM)
 			fprintf(mf, "HRAM:\n");
 		else if (bank == BANK_VRAM || bank == BANK_VRAM + 1)
 			fprintf(mf, "VRAM Bank #%ld:\n", bank - BANK_VRAM);
+		else if (bank < MAXBANKS)
+			fprintf(mf, "SRAM Bank #%ld:\n", bank - BANK_SRAM);
 	}
 	if (sf) {
-		sfbank = (bank >= 1 && bank <= 511) ? bank : 0;
+		if (bank < BANK_WRAM0)
+			sfbank = bank;
+		else if (bank == BANK_WRAM0)
+			sfbank = 0;
+		else if (bank < BANK_VRAM)
+			sfbank = bank - BANK_WRAMX + 1;
+		else if (bank == BANK_HRAM)
+			sfbank = 0;
+		else if (bank == BANK_VRAM || bank == BANK_VRAM + 1)
+			sfbank = bank - BANK_VRAM;
+		else if (bank < MAXBANKS)
+			sfbank = bank - BANK_SRAM;
+		else
+			sfbank = 0;
 	}
 }
 

--- a/src/link/output.c
+++ b/src/link/output.c
@@ -86,7 +86,10 @@ Output(void)
 
 		fclose(f);
 	}
-	for (i = 256; i < MAXBANKS; i += 1) {
+	
+	// Skip all ROM banks, they have been already written. Start from the first non-ROM bank. See "assign.h"
+	
+	for (i = BANK_WRAM0; i < MAXBANKS; i += 1) {
 		struct sSection *pSect;
 		MapfileInitBank(i);
 		pSect = pSections;

--- a/src/link/patch.c
+++ b/src/link/patch.c
@@ -6,6 +6,7 @@
 #include "link/mylink.h"
 #include "link/symbol.h"
 #include "link/main.h"
+#include "link/assign.h"
 
 struct sSection *pCurrentSection;
 SLONG rpnstack[256];
@@ -28,7 +29,7 @@ SLONG
 getsymvalue(SLONG symid)
 {
 	switch (pCurrentSection->tSymbols[symid]->Type) {
-		case SYM_IMPORT:
+	case SYM_IMPORT:
 		return (sym_GetValue(pCurrentSection->tSymbols[symid]->pzName));
 		break;
 	case SYM_EXPORT:
@@ -53,18 +54,32 @@ getsymvalue(SLONG symid)
 SLONG 
 getsymbank(SLONG symid)
 {
+	SLONG nBank;
 	switch (pCurrentSection->tSymbols[symid]->Type) {
-		case SYM_IMPORT:
-		return (sym_GetBank(pCurrentSection->tSymbols[symid]->pzName));
+	case SYM_IMPORT:
+		nBank = (sym_GetBank(pCurrentSection->tSymbols[symid]->pzName));
 		break;
 	case SYM_EXPORT:
 	case SYM_LOCAL:
-		return (pCurrentSection->tSymbols[symid]->pSection->nBank);
-		//return (pCurrentSection->nBank);
+		nBank = (pCurrentSection->tSymbols[symid]->pSection->nBank);
+		//nBank = (pCurrentSection->nBank);
+		break;
 	default:
+		fprintf(stderr, "*INTERNAL* UNKNOWN SYMBOL TYPE\n");
+		exit(1);
 		break;
 	}
-	errx(1, "*INTERNAL* UNKNOWN SYMBOL TYPE");
+
+	//printf("SECTION: %s at bank %d\n",pCurrentSection->tSymbols[symid]->pzName,nBank);
+	
+	if( (nBank >= BANK_WRAMX) && (nBank <= (BANK_WRAMX+6)) )
+		return nBank - BANK_WRAMX + 1;
+	if( (nBank >= BANK_VRAM) && (nBank <= (BANK_VRAM+1)) )
+		return nBank - BANK_VRAM;
+	if( (nBank >= BANK_SRAM) && (nBank <= (BANK_SRAM+3)) )
+		return nBank - BANK_SRAM;
+	
+	return nBank;
 }
 
 SLONG 


### PR DESCRIPTION
Fixed WRAMX, VRAM and SRAM banks, mapfile and symfile generation.

Also fixed compilation under MinGW32.

- WRAMX banks were off by 1. Setting WRAMX,BANK[1] made the linker output to bank 2. That has been fixed, banks 1 to 7 output to the correct one.
- When using BANK() with a symbol in WRAMX, VRAM or SRAM, the linker would return a value based on "link/assign.h" banks instead of the Game Boy bank. Now, it returns the correct number.
- When generating the mapfile and symfile, global symbols of those sections (and sections themselves) didn't appear, only SLACK.
- When trying to assign sections of VRAM, WRAMX or SRAM with both floating org and bank, there was an error when assigning bank.

Test file (init.asm):

```
rVBK EQU $FF4F
rSVBK EQU $FF70

    SECTION "Cartridge Header",HOME[$0100]

    nop
    jp  StartPoint

    DB  $CE,$ED,$66,$66,$CC,$0D,$00,$0B,$03,$73,$00,$83,$00,$0C,$00,$0D
    DB  $00,$08,$11,$1F,$88,$89,$00,$0E,$DC,$CC,$6E,$E6,$DD,$DD,$D9,$99
    DB  $BB,$BB,$67,$63,$6E,$0E,$EC,$CC,$DD,$DC,$99,$9F,$BB,$B9,$33,$3E

    ;    0123456789ABC
    DB  "BANK TEST    "
    DW  $0000
    DB  $C0 ;GBC flag
    DB  0,0,0   ;SuperGameboy
    DB  $12 ;CARTTYPE (MBC3+RAM+Battery)
    DB  0   ;ROMSIZE
    DB  3   ;RAMSIZE (8KB)

    DB  0,0,0,0,0

    SECTION "Program Start",HOME[$0150]

StartPoint:

    di

    ld  a,$A0
    ld  [$0000],a ; Enable SRAM

.loop:

    ld  a,BANK(V00)
    ld  [rVBK],a
    ld  a,BANK(V01)
    ld  [rVBK],a
    ld  a,BANK(V10)
    ld  [rVBK],a
    ld  a,BANK(V11)
    ld  [rVBK],a

    ld  a,BANK(S0)
    ld  [$4000],a
    ld  a,BANK(S1)
    ld  [$4000],a
    ld  a,BANK(S2)
    ld  [$4000],a
    ld  a,BANK(S3)
    ld  [$4000],a

    ld  a,BANK(R1)
    ld  [rSVBK],a
    ld  a,BANK(R2)
    ld  [rSVBK],a
    ld  a,BANK(R3)
    ld  [rSVBK],a
    ld  a,BANK(R4)
    ld  [rSVBK],a
    ld  a,BANK(R5)
    ld  [rSVBK],a
    ld  a,BANK(R6)
    ld  [rSVBK],a
    ld  a,BANK(R7)
    ld  [rSVBK],a
    ld  a,0
    ld  [rSVBK],a
    jr  .loop

;--------------------------------------------------------------------------
;-                              TEST SECTIONS                             -
;--------------------------------------------------------------------------

    SECTION "WRAMX1",WRAMX[$D000],BANK[1]
R1::    DS  $1000
    SECTION "WRAMX2",WRAMX,BANK[2]
R2::    DS  $1000
    SECTION "WRAMX3",WRAMX,BANK[3]
R3::    DS  $1000
    SECTION "WRAMX4",WRAMX,BANK[4]
R4::    DS  $1000
    SECTION "WRAMX5",WRAMX[$D000];,BANK[5]
R5::    DS  $1000
    SECTION "WRAMX6",WRAMX;,BANK[6]
R6::    DS  $1000
    SECTION "WRAMX7",WRAMX;,BANK[7]
R7::    DS  $1000

    SECTION "SRAM0",SRAM[$A000],BANK[0]
S0::    DS  $2000
    SECTION "SRAM1",SRAM,BANK[1]
S1::    DS  $2000
    SECTION "SRAM2",SRAM[$A000];,BANK[2]
S2::    DS  $2000
    SECTION "SRAM3",SRAM;,BANK[3]
S3::    DS  $2000

    SECTION "VRAM00",VRAM[$8000],BANK[0]
V00::   DS  $1000
    SECTION "VRAM01",VRAM,BANK[0]
V01::   DS  $1000
    SECTION "VRAM10",VRAM[$8000];,BANK[1]
V10::   DS  $1000
    SECTION "VRAM11",VRAM;,BANK[1]
V11::   DS  $1000
```

Assemble init.asm:

```
rgbasm -o init.o init.asm
rgblink -o bank_test.gbc -p 0xFF -m bank_test.map -n bank_test.sym init.o
rgbfix -p 0xFF -v bank_test.gbc
pause
```

