### PR TITLE
Command line definitions.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,7 @@ rgbasm_obj = \
 	src/asm/symbol.o \
 	src/asm/locallex.o \
 	src/extern/err.o \
+	src/extern/reallocarray.o \
 	src/extern/strlcpy.o \
 	src/extern/strlcat.o
 

--- a/src/asm/main.c
+++ b/src/asm/main.c
@@ -185,7 +185,7 @@ opt_AddDefine(char *s)
 	if(cldefines_index >= cldefines_size)
 	{
 		cldefines_size *= 2;
-		cldefines = reallocarray(cldefines, cldefines_size
+		cldefines = reallocarray(cldefines, cldefines_size,
 		                        2 * sizeof(void *));
 		if(!cldefines)
 		{
@@ -270,7 +270,8 @@ main(int argc, char *argv[])
 	char *tzMainfile;
 
 	cldefines_size = 32;
-	cldefines = reallocarray(cldefines_size, 2 * sizeof(void *));
+	cldefines = reallocarray(cldefines, cldefines_size,
+	                        2 * sizeof(void *));
 	if(!cldefines)
 	{
 		fatalerror("No memory for command line defines");

--- a/src/asm/rgbasm.1
+++ b/src/asm/rgbasm.1
@@ -9,6 +9,7 @@
 .Op Fl v
 .Op Fl h
 .Op Fl b Ar chars
+.Op Fl D Ar name Ns Op = Ns Ar value
 .Op Fl g Ar chars
 .Op Fl i Ar path
 .Op Fl o Ar outfile
@@ -23,6 +24,12 @@ Its arguments are as follows:
 .It Fl b Ar chars
 Change the two characters used for binary constants.
 The defaults are 01.
+.It Fl D Ar name Ns Op = Ns Ar value
+Add string symbol to the compiled source code. This is equivalent to
+.Ar name
+.Cm EQUS
+.Qq Ar "value"
+in code. If a value is not specified, a value of 1 is given.
 .It Fl g Ar chars
 Change the four characters used for binary constants.
 The defaults are 0123.


### PR DESCRIPTION
Still haven't added this to the manpage yet, but this should hopefully work this time. Do you want me to add a `test/asm/cldefines.asm`? Also, once again, cldefines_size is multiplied by 2 without overflow check.