### PR TITLE
Fix segfault in createpatch() when symbol is an inexistant local label or bank

### DIFF
--- a/src/asm/output.c
+++ b/src/asm/output.c
@@ -386,7 +386,10 @@ createpatch(ULONG type, struct Expression * expr)
 				rpnexpr[rpnptr++] = value >> 16;
 				rpnexpr[rpnptr++] = value >> 24;
 			} else {
-				symptr = addsymbol(sym_FindSymbol(tzSym));
+				struct sSymbol *sym;
+				if ((sym = sym_FindSymbol(tzSym)) == NULL)
+					break;
+				symptr = addsymbol(sym);
 				rpnexpr[rpnptr++] = RPN_SYM;
 				rpnexpr[rpnptr++] = symptr & 0xFF;
 				rpnexpr[rpnptr++] = symptr >> 8;
@@ -394,15 +397,19 @@ createpatch(ULONG type, struct Expression * expr)
 				rpnexpr[rpnptr++] = symptr >> 24;
 			}
 			break;
-		case RPN_BANK:
+		case RPN_BANK: {
+			struct sSymbol *sym;
 			symptr = 0;
 			while ((tzSym[symptr++] = rpn_PopByte(expr)) != 0);
-			symptr = addsymbol(sym_FindSymbol(tzSym));
+			if ((sym = sym_FindSymbol(tzSym)) == NULL)
+				break;
+			symptr = addsymbol(sym);
 			rpnexpr[rpnptr++] = RPN_BANK;
 			rpnexpr[rpnptr++] = symptr & 0xFF;
 			rpnexpr[rpnptr++] = symptr >> 8;
 			rpnexpr[rpnptr++] = symptr >> 16;
 			rpnexpr[rpnptr++] = symptr >> 24;
+			}
 			break;
 		default:
 			rpnexpr[rpnptr++] = rpndata;


### PR DESCRIPTION
Fix issue #68 

Fixed as follows: if the symbol doesn't exist, don't add it to the relocation
table. The functions calling createpatch will nevertheless increment PC
correctly.

Test case:

SECTION "CODE", CODE
glob:
        jp .loc

; from test/asm/banknoexist.asm:
SECTION "sec", ROM0
        db BANK(noexist)

See also issue #68