### PR TITLE
Fix bug with macro args in symbol names

### DIFF
--- a/src/asm/globlex.c
+++ b/src/asm/globlex.c
@@ -161,7 +161,7 @@ ParseSymbol(char *src, ULONG size)
 			if (*src == '@')
 				marg = sym_FindMacroArg(-1);
 			else if (*src >= '0' && *src <= '9')
-				marg = sym_FindMacroArg(*src);
+				marg = sym_FindMacroArg(*src - '0');
 			else {
 				fatalerror("Malformed ID");
 				return (0);


### PR DESCRIPTION
If a macro arg came in the middle of a symbol or at the end, e.g. "SYM\1", it would say that the symbol was not defined. This was because it wasn't looking up the macro arg's value correctly.