### PR TITLE
Add -E option to rgbasm

### DIFF
--- a/include/asm/main.h
+++ b/include/asm/main.h
@@ -9,6 +9,7 @@ struct sOptions {
 	SLONG fillchar;
 	bool verbose;
 	bool haltnop;
+	bool exportall;
 	    //-1 == random
 };
 

--- a/include/asm/symbol.h
+++ b/include/asm/symbol.h
@@ -36,6 +36,7 @@ struct sSymbol {
 					 * not be changed during linking */
 
 ULONG calchash(char *s);
+void sym_SetExportAll(BBOOL set);
 void sym_PrepPass1(void);
 void sym_PrepPass2(void);
 void sym_AddLocalReloc(char *tzSym);

--- a/src/asm/main.c
+++ b/src/asm/main.c
@@ -257,7 +257,7 @@ static void
 usage(void)
 {
 	printf(
-"Usage: rgbasm [-hv] [-b chars] [-Dname[=value]] [-g chars] [-i path]\n"
+"Usage: rgbasm [-hvE] [-b chars] [-Dname[=value]] [-g chars] [-i path]\n"
 "              [-o outfile] [-p pad_value] file.asm\n");
 	exit(1);
 }
@@ -296,12 +296,13 @@ main(int argc, char *argv[])
 	DefaultOptions.fillchar = 0;
 	DefaultOptions.verbose = false;
 	DefaultOptions.haltnop = true;
+	DefaultOptions.exportall = false;
 
 	opt_SetCurrentOptions(&DefaultOptions);
 
 	newopt = CurrentOptions;
 
-	while ((ch = getopt(argc, argv, "b:D:g:hi:o:p:v")) != -1) {
+	while ((ch = getopt(argc, argv, "b:D:g:hi:o:p:vE")) != -1) {
 		switch (ch) {
 		case 'b':
 			if (strlen(optarg) == 2) {
@@ -348,6 +349,9 @@ main(int argc, char *argv[])
 		case 'v':
 			newopt.verbose = true;
 			break;
+		case 'E':
+			newopt.exportall = true;
+			break;
 		default:
 			usage();
 		}
@@ -379,6 +383,7 @@ main(int argc, char *argv[])
 	nPass = 1;
 	nErrors = 0;
 	sym_PrepPass1();
+	sym_SetExportAll(CurrentOptions.exportall);
 	fstk_Init(tzMainfile);
 	opt_ParseDefines();
 

--- a/src/asm/output.c
+++ b/src/asm/output.c
@@ -243,25 +243,27 @@ writesymbol(struct sSymbol * pSym, FILE * f)
 		offset = 0;
 		sectid = -1;
 		type = SYM_IMPORT;
-	} else if (pSym->nType & SYMF_EXPORT) {
-		/* Symbol should be exported */
-		strcpy(symname, pSym->tzName);
-		type = SYM_EXPORT;
-		offset = pSym->nValue;
-		if (pSym->nType & SYMF_CONST)
-			sectid = -1;
-		else
-			sectid = getsectid(pSym->pSection);
 	} else {
-		/* Symbol is local to this file */
 		if (pSym->nType & SYMF_LOCAL) {
 			strcpy(symname, pSym->pScope->tzName);
 			strcat(symname, pSym->tzName);
 		} else
 			strcpy(symname, pSym->tzName);
-		type = SYM_LOCAL;
-		offset = pSym->nValue;
-		sectid = getsectid(pSym->pSection);
+		
+		if (pSym->nType & SYMF_EXPORT) {
+			/* Symbol should be exported */
+			type = SYM_EXPORT;
+			offset = pSym->nValue;
+			if (pSym->nType & SYMF_CONST)
+				sectid = -1;
+			else
+				sectid = getsectid(pSym->pSection);
+		} else {
+			/* Symbol is local to this file */
+			type = SYM_LOCAL;
+			offset = pSym->nValue;
+			sectid = getsectid(pSym->pSection);
+		}
 	}
 
 	fputstring(symname, f);
@@ -282,6 +284,7 @@ addsymbol(struct sSymbol * pSym)
 	struct PatchSymbol *pPSym, **ppPSym;
 	static ULONG nextID = 0;
 	ULONG hash;
+	
 
 	hash = calchash(pSym->tzName);
 	ppPSym = &(tHashedPatchSymbols[hash]);

--- a/src/asm/rgbasm.1
+++ b/src/asm/rgbasm.1
@@ -52,6 +52,8 @@ When padding an image, pad with this value.
 The default is 0x00.
 .It Fl v
 Be verbose.
+.It Fl E
+Export all relocable symbols by default.
 .El
 .Sh EXAMPLES
 Assembling a basic source file is simple:

--- a/src/asm/symbol.c
+++ b/src/asm/symbol.c
@@ -21,6 +21,7 @@ char *currentmacroargs[MAXMACROARGS + 1];
 char *newmacroargs[MAXMACROARGS + 1];
 char SavedTIME[256];
 char SavedDATE[256];
+bool exportall;
 
 SLONG 
 Callback_NARG(struct sSymbol * sym)
@@ -575,6 +576,9 @@ sym_AddLocalReloc(char *tzSym)
 				nsym->nValue = nPC;
 				nsym->nType |=
 				    SYMF_RELOC | SYMF_LOCAL | SYMF_DEFINED;
+				if (exportall) {
+				   nsym->nType |= SYMF_EXPORT;
+				}
 				nsym->pScope = pScope;
 				nsym->pSection = pCurrentSection;
 			}
@@ -604,6 +608,9 @@ sym_AddReloc(char *tzSym)
 		if (nsym) {
 			nsym->nValue = nPC;
 			nsym->nType |= SYMF_RELOC | SYMF_DEFINED;
+			if (exportall) {
+			   nsym->nType |= SYMF_EXPORT;
+			}
 			nsym->pScope = NULL;
 			nsym->pSection = pCurrentSection;
 		}
@@ -707,6 +714,13 @@ sym_AddMacro(char *tzSym)
 			nsym->pMacro = tzNewMacro;
 		}
 	}
+}
+
+/* 
+ * Set whether to export all relocable symbols by default
+ */
+void sym_SetExportAll(BBOOL set) {
+	exportall = set;
 }
 
 /*


### PR DESCRIPTION
This option makes all labels exported by default.  The main reason you might want to do this is to print all symbols, including unreferenced ones and local ones into the symfile, to ease debugging.