### PR TITLE
Don't redefine strupr/strlwr on MinGW

### DIFF
--- a/include/asm/lexer.h
+++ b/include/asm/lexer.h
@@ -60,8 +60,10 @@ extern void yyunputbytes(ULONG count);
 extern YY_BUFFER_STATE pCurrentBuffer;
 
 #ifdef __GNUC__
+#ifndef __MINGW32__
 extern void strupr(char *s);
 extern void strlwr(char *s);
+#endif
 #endif
 
 #endif

--- a/src/asm/lexer.c
+++ b/src/asm/lexer.c
@@ -40,6 +40,7 @@ ULONG nFloating;
 enum eLexerState lexerstate = LEX_STATE_NORMAL;
 
 #ifdef __GNUC__
+#ifndef __MINGW32__
 void 
 strupr(char *s)
 {
@@ -57,6 +58,7 @@ strlwr(char *s)
 		s += 1;
 	}
 }
+#endif
 #endif
 void 
 yyskipbytes(ULONG count)


### PR DESCRIPTION
> MinGW already includes support for strupr and strlwr so this isn't needed
> there, and these definitions are incompatible (with MS versions) anyway.
> Even better would be to detect toolchain support at build time.

Alternatively they could be renamed (e.g. `rgb_strupr`, `rgb_strlwr`) and
always used in place of any system version; I can put together another PR
if that method is preferred.