### PR TITLE
Add option to mark the ROM bank number in each one

### DIFF
--- a/include/link/mylink.h
+++ b/include/link/mylink.h
@@ -10,6 +10,7 @@
 extern SLONG options;
 #define OPT_SMALL	0x01
 #define OPT_SMART_C_LINK	0x02
+#define OPT_BANK_NUM_BYTE	0x04
 
 enum eRpnData {
 	RPN_ADD = 0,

--- a/src/link/assign.c
+++ b/src/link/assign.c
@@ -415,6 +415,10 @@ AssignSections(void)
 			} else {
 				BankFree[i]->nSize = 0x4000;
 				MaxAvail[i] = 0x4000;
+				if (options & OPT_BANK_NUM_BYTE) {
+					/* Reserve last byte of each ROM bank for its number. */
+					BankFree[i]->nSize --;
+				}
 			}
 		} else if (i == BANK_WRAM0) {
 			/* WRAM */

--- a/src/link/main.c
+++ b/src/link/main.c
@@ -35,7 +35,7 @@ static void
 usage(void)
 {
 	printf(
-"usage: rgblink [-t] [-m mapfile] [-n symfile] [-o outfile] [-p pad_value]\n"
+"usage: rgblink [-bt] [-m mapfile] [-n symfile] [-o outfile] [-p pad_value]\n"
 "               [-s symbol] file [...]\n");
 	exit(1);
 }
@@ -56,8 +56,11 @@ main(int argc, char *argv[])
 
 	progname = argv[0];
 
-	while ((ch = getopt(argc, argv, "m:n:o:p:s:t")) != -1) {
+	while ((ch = getopt(argc, argv, "bm:n:o:p:s:t")) != -1) {
 		switch (ch) {
+		case 'b':
+			options |= OPT_BANK_NUM_BYTE;
+			break;
 		case 'm':
 			SetMapfileName(optarg);
 			break;


### PR DESCRIPTION
Added option -b for rgblink, which will reserve the last byte of each
ROMX bank (not ROM0), and for rgbfix, which will write the ROMX
number on said byte. It only works with ROMs with more than 2 ROM
banks and less or equal than 256 banks (because it would overflow).

This is useful for some systems of handling ROM banks.