### PR TITLE
Fix GB graphics prefix output

### DIFF
--- a/src/asm/globlex.c
+++ b/src/asm/globlex.c
@@ -97,7 +97,7 @@ ascii2bin(char *s)
 
 		while (*s != '\0') {
 			c = convertfunc(*s++);
-			result = result * 2 + ((c & 1) << 8) + ((c & 2) >> 1);
+			result = result * 2 + ((c & 2) << 7) + (c & 1);
 		}
 	} else {
 		while (*s != '\0')


### PR DESCRIPTION
The output of using the prefix '`' was inverted: The MSB was placed
before the LSB. Now, the LSB are placed first, allowing a direct copy
to VRAM.

Fixes: https://github.com/bentley/rgbds/issues/87