### PR TITLE
added "SYMSTR()" assembler function

### DIFF
--- a/src/asm/asmy.y
+++ b/src/asm/asmy.y
@@ -464,6 +464,7 @@ void	if_skip_to_endc( void )
 %left	T_OP_STRCAT
 %left	T_OP_STRUPR
 %left	T_OP_STRLWR
+%left	T_OP_SYMSTR 
 
 %left	NEG     /* negation--unary minus */
 
@@ -1082,6 +1083,8 @@ string			:	T_STRING
 					{ strcpy($$,$3); upperstring($$); }
 				|	T_OP_STRLWR '(' string ')'
 					{ strcpy($$,$3); lowerstring($$); }
+				|  T_OP_SYMSTR '(' string ')' 
+					{ symvaluetostring($$, 64, $3); } 
 ;
 section:
 		T_POP_SECTION string ',' sectiontype

--- a/src/asm/globlex.c
+++ b/src/asm/globlex.c
@@ -288,6 +288,7 @@ struct sLexInitString staticstrings[] = {
 	{"strcat", T_OP_STRCAT},
 	{"strupr", T_OP_STRUPR},
 	{"strlwr", T_OP_STRLWR},
+	{"symstr", T_OP_SYMSTR}, 
 
 	{"include", T_POP_INCLUDE},
 	{"printt", T_POP_PRINTT},


### PR DESCRIPTION
"SYMSTR()" returns a symboles string.
example usage: db SYMSTR("**DATE**")
