### PR TITLE
Fixes rgbgfx build issues with old libpng (pre 1.4.2)

### DIFF
--- a/src/gfx/makepng.c
+++ b/src/gfx/makepng.c
@@ -163,7 +163,11 @@ input_png_file(struct Options opts, struct PNGImage *img)
 	 * Also unfortunately, this sets it at 8 bit, and I can't find any
 	 * option to reduce to 2 or 1 bit.
 	 */
+#if PNG_LIBPNG_VER < 10402
+	png_set_dither(img->png, palette, colors, colors, NULL, 1);
+#else
 	png_set_quantize(img->png, palette, colors, colors, NULL, 1);
+#endif
 
 	if (!has_palette) {
 		png_set_PLTE(img->png, img->info, palette, colors);


### PR DESCRIPTION
- [x] Tested with libpng 1.6.26 on macOS Sierra (10.12.2)
- [x] Tested with libpng 1.2.50 on Raspbian 8 (Jessie)