### PR TITLE
Fix command line interface for adding include paths

### DIFF
--- a/include/asm/asm.h
+++ b/include/asm/asm.h
@@ -30,6 +30,6 @@ extern struct sSymbol *pPCSymbol;
 extern bool oDontExpandStrings;
 
 #define MAXMACROARGS	256
-#define MAXINCPATHS		16
+#define MAXINCPATHS		128
 
 #endif	/* //       ASM_H */

--- a/src/asm/fstack.c
+++ b/src/asm/fstack.c
@@ -179,6 +179,16 @@ fstk_Dump(void)
 void 
 fstk_AddIncludePath(char *s)
 {
+	if (NextIncPath == MAXINCPATHS) {
+		fatalerror("Too many include directories passed from command line");
+		return;
+	}
+
+	if (strlen(s) > _MAX_PATH) {
+		fatalerror("Include path too long '%s'",s);
+		return;
+	}
+
 	strcpy(IncludePaths[NextIncPath++], s);
 }
 


### PR DESCRIPTION
The current code doesn't check for errors, doesn't give descriptive error messages and can even crash the program because of string overflows. Added a few checks for it.

Also, the number of include paths allowed is too small for big projects, so it has been increased.