### PR TITLE
Add noreturn attribute to fatalerror()

### DIFF
--- a/include/asm/main.h
+++ b/include/asm/main.h
@@ -2,6 +2,7 @@
 #define	RGBDS_MAIN_H
 
 #include <stdbool.h>
+#include "extern/stdnoreturn.h"
 
 struct sOptions {
 	char gbgfx[4];
@@ -24,7 +25,7 @@ extern void opt_Push(void);
 extern void opt_Pop(void);
 extern void opt_Parse(char *s);
 
-void fatalerror(const char *fmt, ...);
+noreturn void fatalerror(const char *fmt, ...);
 void yyerror(const char *fmt, ...);
 
 #define	YY_FATAL_ERROR fatalerror


### PR DESCRIPTION
Should silence compiler warnings that expect `fatalerror()` to return.