### PR TITLE
Emit a single error when using BANK incorrectly

### DIFF
--- a/src/asm/asmy.y
+++ b/src/asm/asmy.y
@@ -24,7 +24,7 @@ void
 bankrangecheck(char *name, ULONG secttype, SLONG org, SLONG bank)
 {
 	SLONG minbank, maxbank;
-	char *stype;
+	char *stype = NULL;
 	switch (secttype) {
 	case SECT_ROMX:
 		stype = "ROMX";
@@ -51,7 +51,7 @@ bankrangecheck(char *name, ULONG secttype, SLONG org, SLONG bank)
 		    "ROMX, WRAMX, SRAM, or VRAM sections");
 	}
 
-	if (bank < minbank || bank > maxbank) {
+	if (stype && (bank < minbank || bank > maxbank)) {
 		yyerror("%s bank value $%x out of range ($%x to $%x)",
 		    stype, bank, minbank, maxbank);
 	}


### PR DESCRIPTION
Previously, if `BANK` is used when defining a section that’s not `ROMX`,
`WRMAX`, `SRAM` or `VRAM`, a second error message may appear, e.g. “(null)
bank value $1 out of range $5d to $0”.

This would appear due to the usage of uninitialised variables. This
change ensures that the uninitialised variables are not accessed when
using an invalid section with `BANK`.

This also silences compiler warnings about usage of uninitialised
variables.