### PR TITLE
Add ldi a, [hl] and ldd a, [hl] instructions

### DIFF
--- a/src/asm/asmy.y
+++ b/src/asm/asmy.y
@@ -1263,11 +1263,15 @@ z80_ldi			:	T_Z80_LDI T_MODE_HL_IND comma T_MODE_A
 					{ out_AbsByte(0x02|(2<<4)); }
 				|	T_Z80_LDI T_MODE_A comma T_MODE_HL
 					{ out_AbsByte(0x0A|(2<<4)); }
+				|	T_Z80_LDI T_MODE_A comma T_MODE_HL_IND
+					{ out_AbsByte(0x0A|(2<<4)); }
 ;
 
 z80_ldd			:	T_Z80_LDD T_MODE_HL_IND comma T_MODE_A
 					{ out_AbsByte(0x02|(3<<4)); }
 				|	T_Z80_LDD T_MODE_A comma T_MODE_HL
+					{ out_AbsByte(0x0A|(3<<4)); }
+				|	T_Z80_LDD T_MODE_A comma T_MODE_HL_IND
 					{ out_AbsByte(0x0A|(3<<4)); }
 ;
 


### PR DESCRIPTION
These are equivalent to `ld a, [hl+]` and `ld a, [hl-]` respectively. The previous `ldi a, hl` and `ldd a, hl` remain intact. Fixes #73.